### PR TITLE
use carlos/historical nonbonded cutoff parameters when default argume…

### DIFF
--- a/open3SPN2/force/dna.py
+++ b/open3SPN2/force/dna.py
@@ -516,7 +516,7 @@ class Electrostatics(DNAForce, openmm.CustomNonbondedForce):
         ldby = ldby.in_units_of(unit.nanometer)
 
         if self.cutoff_distance == None:
-            cutoff_distance = ldby * 4
+            cutoff_distance = 5 #should retain former value, not ldby * 4
         else:
             cutoff_distance = self.cutoff_distance
 

--- a/open3SPN2/force/protein_dna.py
+++ b/open3SPN2/force/protein_dna.py
@@ -129,7 +129,7 @@ class ElectrostaticsProteinDNA(ProteinDNAForce):
         electrostaticForce.addGlobalParameter('inter_denominator', denominator)
 
         if self.cutoff_distance == None:
-            cutoff_distance = ldby * 4
+            cutoff_distance = 4 #should retain former value, not ldby * 4
         else:
             cutoff_distance = self.cutoff_distance
 


### PR DESCRIPTION
…nts are passed for dna-dna and protein-dna electrostatics